### PR TITLE
Fix/navbar boolean error

### DIFF
--- a/src/components/NavigationBar/NavigationBar.stories.js
+++ b/src/components/NavigationBar/NavigationBar.stories.js
@@ -109,7 +109,7 @@ export const Playground = ({ isSticky, iconMenu, ...args }) => {
 
 Playground.args = {
   rightContent: (
-    <Dropdown label={<IconUser style={{ marginRight: '30px' }} />}>
+    <Dropdown align="right" label={<IconUser style={{ marginRight: '30px' }} />}>
       <ListItem leftContent={<IconUser />}>Text</ListItem>
       <ListItem leftContent={<IconUpdate />}>Text</ListItem>
     </Dropdown>

--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -176,13 +176,7 @@ const NavigationBar = props => {
             </Dropdown>
           </StyledDropdown>
         )}
-        {header && (
-          <NavigationLeftHeader>
-            {React.cloneElement(header, {
-              sticked
-            })}
-          </NavigationLeftHeader>
-        )}
+        {header && <NavigationLeftHeader>{React.cloneElement(header)}</NavigationLeftHeader>}
       </NavigationLeft>
 
       <NavigationRight>
@@ -190,17 +184,13 @@ const NavigationBar = props => {
           <NavigationContent>
             <NavigationLink>
               {Children.map(children, child => (
-                <NavigationLinkItem>{React.cloneElement(child, { sticked })}</NavigationLinkItem>
+                <NavigationLinkItem>{React.cloneElement(child)}</NavigationLinkItem>
               ))}
             </NavigationLink>
           </NavigationContent>
         )}
         {rightContent && (
-          <NavigationRightContent>
-            {React.cloneElement(rightContent, {
-              sticked
-            })}
-          </NavigationRightContent>
+          <NavigationRightContent>{React.cloneElement(rightContent)}</NavigationRightContent>
         )}
       </NavigationRight>
     </StyledNavigation>


### PR DESCRIPTION
El componente Navbar estaba dando este error:

![image](https://user-images.githubusercontent.com/47493473/106455111-06f74700-648c-11eb-96f1-e2a8cce267b7.png)

He probado diferentes temas para solucionarlo reseñadas en la documentación de Styled Components (destructuring de propiedades, transient properties, etc), y probado todas con el componente principal.
Sin embargo, el problema no está en el componente principal, que está ya aceptando la propiedad "sticked" sin pasarla al dom y por tanto no da error.
El problema se encuentra en los componentes NavigationRight y NavigationLeft que estaban recibiendo el la propiedad "sticked" al hacer el React.cloneElement.
Los styledcomponents para estos componentes no están utilizando esta propiedad para nada, por lo que esa propiedad pasa al DOM de los children. IMHO, al no usarse con styledComponents, la librería no quita esta propiedad del DOM del children y de ahí que detecte que no es un valor esperado.

Hay otra solución más sencilla sin modificar mucho, que es cambiar el PropType de boolean a String, y hacer casting de la "sticked" a string cuando se recibe, pero esto es hacky.

He comprobado si otros componentes usan la propiedad "sticked" y no parece que ninguno más de los children que puede recibir lo estén usando.



