### PR TITLE
feat: add overlay opacity variable

### DIFF
--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -64,6 +64,12 @@ export default {
       table: {
         category: 'format'
       }
+    },
+    opacity: {
+      description: 'Changes the opacity of the backing overlay',
+      table: {
+        category: 'format'
+      }
     }
   },
   args: {

--- a/src/components/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/components/Modal/__snapshots__/Modal.stories.storyshot
@@ -541,7 +541,8 @@ exports[`Storyshots Modal Playground 1`] = `
     </span>
   </button>
   <div
-    className="Modal__StyledOverlay-sc-18autff-5 fMKtSc"
+    className="Modal__StyledOverlay-sc-18autff-5 byeIOI"
+    opacity={0.3}
   >
     <div
       className="Modal__StyledContainer-sc-18autff-0 jHJDJs"

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -67,7 +67,7 @@ StyledFooter.defaultProps = {
 };
 
 const StyledOverlay = styled.div`
-  background-color: ${({ theme }) => hexToRgba(theme.color.charcoal800, 0.2)};
+  background-color: ${({ theme, opacity }) => hexToRgba(theme.color.charcoal800, opacity)};
   position: fixed;
   left: 0;
   top: 0;
@@ -92,6 +92,7 @@ const Modal = ({
   header,
   isOpen,
   onClose,
+  opacity,
   zIndex,
   ...other
 }) => {
@@ -116,7 +117,7 @@ const Modal = ({
   }, [isOpen]);
 
   return isOpen ? (
-    <StyledOverlay zIndex={zIndex}>
+    <StyledOverlay zIndex={zIndex} opacity={opacity}>
       <StyledContainer {...other} ref={ref}>
         {((header && header.props.children) || closable) && (
           <StyledHeader hasHeading={header && header.props.children} closable={closable}>
@@ -144,13 +145,15 @@ Modal.propTypes = {
   onClose: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
   full: PropTypes.bool.isRequired,
-  zIndex: PropTypes.number
+  zIndex: PropTypes.number,
+  opacity: PropTypes.number
 };
 
 Modal.defaultProps = {
   full: false,
   closable: true,
   enableClickOutside: true,
-  zIndex: 9999
+  zIndex: 9999,
+  opacity: 0.3
 };
 export default Modal;


### PR DESCRIPTION
Tweak S31: hacer los overlays de los modales más opacos:
- Subido por defecto a 0.3 en lugar de 0.2 como estaba.
- Puesto como variable para que se pueda personalizar. 
- Actualizo story
![1d4941a74ddaad9206f9eee933f36953](https://user-images.githubusercontent.com/47493473/109171698-51fe3480-7782-11eb-92f7-08833416762b.gif)


