### PR TITLE
Feature/inline input suffix

### DIFF
--- a/src/components/FormGroup/__snapshots__/FormGroup.stories.storyshot
+++ b/src/components/FormGroup/__snapshots__/FormGroup.stories.storyshot
@@ -17,7 +17,7 @@ exports[`Storyshots FormGroup Playground 1`] = `
         className="InputField__Label-sc-1kf04eo-3 ckeGRO"
       >
         <input
-          className="InputField__Input-sc-1kf04eo-2 ePOZCe"
+          className="InputField__Input-sc-1kf04eo-2 fpIUFd"
           disabled={false}
           placeholder="Type your email address"
           type="email"
@@ -40,7 +40,7 @@ exports[`Storyshots FormGroup Playground 1`] = `
         className="InputField__Label-sc-1kf04eo-3 ckeGRO"
       >
         <input
-          className="InputField__Input-sc-1kf04eo-2 fxADbd"
+          className="InputField__Input-sc-1kf04eo-2 pcwob"
           disabled={false}
           placeholder="Type your password"
           type="password"

--- a/src/components/InlineInputField/InlineInputField.stories.js
+++ b/src/components/InlineInputField/InlineInputField.stories.js
@@ -191,8 +191,19 @@ export const WithInnerLabels = () => (
   <div style={{ width: '400px' }}>
     <div style={{ ...decoratorStyles }}>
       <InlineInputField label="With prefix and suffix" prefix="1.280€" suffix="%" value="2" />
+    </div>
+    <div style={{ ...decoratorStyles }}>
+      {' '}
       <InlineInputField label="Only prefix" prefix="1.280€" value="2" />
+    </div>
+
+    <div style={{ ...decoratorStyles }}>
+      {' '}
       <InlineInputField label="Only prefix disabled" disabled prefix="1.280€" value="2" />
+    </div>
+
+    <div style={{ ...decoratorStyles }}>
+      {' '}
       <InlineInputField label="Only suffix" suffix="%" value="2" />
     </div>
   </div>

--- a/src/components/InlineInputField/InlineInputField.stories.js
+++ b/src/components/InlineInputField/InlineInputField.stories.js
@@ -19,6 +19,21 @@ export default {
         category: 'behaviour'
       }
     },
+    inputBackground: {
+      description:
+        'Sets a background color for the input when not focus or error. Transparent by default.',
+      control: 'color',
+      table: {
+        category: 'format'
+      }
+    },
+    inputFontColor: {
+      descriptrion: 'Sets a custom color for the font color',
+      control: 'color',
+      table: {
+        category: 'format'
+      }
+    },
     error: {
       description: 'Adds falsy style to the field',
       table: {
@@ -91,6 +106,13 @@ export default {
     prefix: {
       description:
         'Inserts a label with custom text in the left side of the input. The input text will not override the prefix. This option also changes the full style of the field to be used as a narrower variant.',
+      table: {
+        category: 'content'
+      }
+    },
+    suffix: {
+      description:
+        'Inserts a string on the right side of the input. It will be right next to it, and will always force the text-align to the right.',
       table: {
         category: 'content'
       }
@@ -172,17 +194,13 @@ Disabled.args = {
   disabled: true
 };
 
-export const WithInnerLabels = args => (
-  <div style={{ width: '250px' }}>
+export const WithInnerLabels = () => (
+  <div style={{ width: '400px' }}>
     <div style={{ ...decoratorStyles }}>
-      <InlineInputField {...args} />
+      <InlineInputField label="With prefix and suffix" prefix="1.280€" suffix="%" value="2" />
+      <InlineInputField label="Only prefix" prefix="1.280€" value="2" />
+      <InlineInputField label="Only prefix disabled" disabled prefix="1.280€" value="2" />
+      <InlineInputField label="Only suffix" suffix="%" value="2" />
     </div>
   </div>
 );
-
-WithInnerLabels.args = {
-  prefix: '1.280€ ',
-  label: '',
-  help: '',
-  value: '25%'
-};

--- a/src/components/InlineInputField/InlineInputField.stories.js
+++ b/src/components/InlineInputField/InlineInputField.stories.js
@@ -27,13 +27,6 @@ export default {
         category: 'format'
       }
     },
-    inputFontColor: {
-      descriptrion: 'Sets a custom color for the font color',
-      control: 'color',
-      table: {
-        category: 'format'
-      }
-    },
     error: {
       description: 'Adds falsy style to the field',
       table: {

--- a/src/components/InlineInputField/InlineInputField.stories.js
+++ b/src/components/InlineInputField/InlineInputField.stories.js
@@ -53,6 +53,18 @@ export default {
         category: 'others'
       }
     },
+    narrow: {
+      description: 'Displays a narrower version of the field',
+      table: {
+        category: 'format'
+      }
+    },
+    boldContent: {
+      description: 'Displays the value and suffix in bold or not. Prefix is always bold',
+      table: {
+        category: 'format'
+      }
+    },
     onChange: {
       description: ' Method to handle onChange event',
       action: 'click OnChange',
@@ -190,7 +202,14 @@ Disabled.args = {
 export const WithInnerLabels = () => (
   <div style={{ width: '400px' }}>
     <div style={{ ...decoratorStyles }}>
-      <InlineInputField label="With prefix and suffix" prefix="1.280€" suffix="%" value="2" />
+      <InlineInputField
+        narrow={true}
+        label="With prefix, suffix and narrow"
+        prefix="1.280€"
+        suffix="% yoy"
+        value="2"
+        boldContent={true}
+      />
     </div>
     <div style={{ ...decoratorStyles }}>
       {' '}

--- a/src/components/InlineInputField/__snapshots__/InlineInputField.stories.storyshot
+++ b/src/components/InlineInputField/__snapshots__/InlineInputField.stories.storyshot
@@ -36,7 +36,7 @@ exports[`Storyshots InlineInputField Disabled 1`] = `
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 hSxllS suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 ibraJM suffix"
           disabled={true}
         />
       </div>
@@ -87,7 +87,7 @@ exports[`Storyshots InlineInputField Error 1`] = `
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
           disabled={false}
         />
       </div>
@@ -139,7 +139,7 @@ exports[`Storyshots InlineInputField Playground 1`] = `
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
           disabled={false}
         />
       </div>
@@ -190,7 +190,7 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
           disabled={false}
         />
       </div>
@@ -776,7 +776,7 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
           disabled={false}
         />
       </div>
@@ -1362,7 +1362,7 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
           disabled={false}
         />
       </div>
@@ -1402,7 +1402,7 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
           disabled={false}
         />
       </div>
@@ -1999,7 +1999,7 @@ exports[`Storyshots InlineInputField With Icon 1`] = `
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
           disabled={false}
         />
       </div>
@@ -2052,7 +2052,7 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
           prefix="1.280€"
         >
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 ApwTw prefix"
+            className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx prefix"
             disabled={false}
           >
             1.280€
@@ -2065,7 +2065,7 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
             value="2"
           />
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 ghDJHO suffix"
+            className="InlineInputField__InnerLabel-jwshkl-8 dtkNsR suffix"
             disabled={false}
             prefix="1.280€"
           >
@@ -2074,6 +2074,15 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
         </div>
       </div>
     </div>
+  </div>
+  <div
+    style={
+      Object {
+        "padding": "2rem",
+      }
+    }
+  >
+     
     <div
       className="InlineInputField__FullInputContainer-jwshkl-0 cWbDNN"
       label="Only prefix"
@@ -2097,7 +2106,7 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
           prefix="1.280€"
         >
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 ApwTw prefix"
+            className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx prefix"
             disabled={false}
           >
             1.280€
@@ -2110,13 +2119,22 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
             value="2"
           />
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 ghDJHO suffix"
+            className="InlineInputField__InnerLabel-jwshkl-8 dtkNsR suffix"
             disabled={false}
             prefix="1.280€"
           />
         </div>
       </div>
     </div>
+  </div>
+  <div
+    style={
+      Object {
+        "padding": "2rem",
+      }
+    }
+  >
+     
     <div
       className="InlineInputField__FullInputContainer-jwshkl-0 cWbDNN"
       label="Only prefix disabled"
@@ -2140,7 +2158,7 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
           prefix="1.280€"
         >
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 hSxllS prefix"
+            className="InlineInputField__InnerLabel-jwshkl-8 ibraJM prefix"
             disabled={true}
           >
             1.280€
@@ -2153,13 +2171,22 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
             value="2"
           />
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 cJETTp suffix"
+            className="InlineInputField__InnerLabel-jwshkl-8 cnGIno suffix"
             disabled={true}
             prefix="1.280€"
           />
         </div>
       </div>
     </div>
+  </div>
+  <div
+    style={
+      Object {
+        "padding": "2rem",
+      }
+    }
+  >
+     
     <div
       className="InlineInputField__FullInputContainer-jwshkl-0 cWbDNN"
       label="Only suffix"
@@ -2187,7 +2214,7 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
             value="2"
           />
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+            className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
             disabled={false}
           >
             %

--- a/src/components/InlineInputField/__snapshots__/InlineInputField.stories.storyshot
+++ b/src/components/InlineInputField/__snapshots__/InlineInputField.stories.storyshot
@@ -16,7 +16,7 @@ exports[`Storyshots InlineInputField Disabled 1`] = `
       className="InlineInputField__Label-jwshkl-7 kZozSM"
     >
       <p
-        className="InlineInputField__LabelText-jwshkl-1 gzviAo"
+        className="InlineInputField__LabelText-jwshkl-1 dSHaNK"
         disabled={true}
       >
         Label text
@@ -26,14 +26,18 @@ exports[`Storyshots InlineInputField Disabled 1`] = `
       className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
     >
       <div
-        className="InlineInputField__InputWrapper-jwshkl-4 bInEel"
+        className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 gIJAcl"
+          className="InlineInputField__Input-jwshkl-5 iuWgyE"
           disabled={true}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
+        />
+        <p
+          className="InlineInputField__InnerLabel-jwshkl-8 hSxllS suffix"
+          disabled={true}
         />
       </div>
     </div>
@@ -63,7 +67,7 @@ exports[`Storyshots InlineInputField Error 1`] = `
       className="InlineInputField__Label-jwshkl-7 kZozSM"
     >
       <p
-        className="InlineInputField__LabelText-jwshkl-1 gzviAo"
+        className="InlineInputField__LabelText-jwshkl-1 eufKgE"
         disabled={false}
       >
         Label text
@@ -73,14 +77,18 @@ exports[`Storyshots InlineInputField Error 1`] = `
       className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
     >
       <div
-        className="InlineInputField__InputWrapper-jwshkl-4 bInEel"
+        className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 gIJAcl error"
+          className="InlineInputField__Input-jwshkl-5 iuWgyE error"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
+        />
+        <p
+          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          disabled={false}
         />
       </div>
     </div>
@@ -111,7 +119,7 @@ exports[`Storyshots InlineInputField Playground 1`] = `
     >
       
       <p
-        className="InlineInputField__LabelText-jwshkl-1 gzviAo"
+        className="InlineInputField__LabelText-jwshkl-1 eufKgE"
         disabled={false}
       >
         Label text
@@ -121,14 +129,18 @@ exports[`Storyshots InlineInputField Playground 1`] = `
       className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
     >
       <div
-        className="InlineInputField__InputWrapper-jwshkl-4 bInEel"
+        className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 gIJAcl"
+          className="InlineInputField__Input-jwshkl-5 iuWgyE"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
+        />
+        <p
+          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          disabled={false}
         />
       </div>
     </div>
@@ -158,7 +170,7 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
       className="InlineInputField__Label-jwshkl-7 kZozSM"
     >
       <p
-        className="InlineInputField__LabelText-jwshkl-1 gzviAo"
+        className="InlineInputField__LabelText-jwshkl-1 eufKgE"
         disabled={false}
       >
         very long label to test reactivity
@@ -168,14 +180,18 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
       className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
     >
       <div
-        className="InlineInputField__InputWrapper-jwshkl-4 bInEel"
+        className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 dmoHjr"
+          className="InlineInputField__Input-jwshkl-5 hzLOcN"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
+        />
+        <p
+          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          disabled={false}
         />
       </div>
     </div>
@@ -740,7 +756,7 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
         </svg>
       </span>
       <p
-        className="InlineInputField__LabelText-jwshkl-1 gzviAo"
+        className="InlineInputField__LabelText-jwshkl-1 eufKgE"
         disabled={false}
       >
         label
@@ -750,14 +766,18 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
       className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
     >
       <div
-        className="InlineInputField__InputWrapper-jwshkl-4 bInEel"
+        className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 gIJAcl"
+          className="InlineInputField__Input-jwshkl-5 iuWgyE"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
+        />
+        <p
+          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          disabled={false}
         />
       </div>
     </div>
@@ -1322,7 +1342,7 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
         </svg>
       </span>
       <p
-        className="InlineInputField__LabelText-jwshkl-1 gzviAo"
+        className="InlineInputField__LabelText-jwshkl-1 eufKgE"
         disabled={false}
       >
         label with icon
@@ -1332,14 +1352,18 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
       className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
     >
       <div
-        className="InlineInputField__InputWrapper-jwshkl-4 bInEel"
+        className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 dmoHjr"
+          className="InlineInputField__Input-jwshkl-5 hzLOcN"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
+        />
+        <p
+          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          disabled={false}
         />
       </div>
     </div>
@@ -1358,7 +1382,7 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
       className="InlineInputField__Label-jwshkl-7 kZozSM"
     >
       <p
-        className="InlineInputField__LabelText-jwshkl-1 gzviAo"
+        className="InlineInputField__LabelText-jwshkl-1 eufKgE"
         disabled={false}
       >
         label no icon
@@ -1368,14 +1392,18 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
       className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
     >
       <div
-        className="InlineInputField__InputWrapper-jwshkl-4 bInEel"
+        className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 gIJAcl"
+          className="InlineInputField__Input-jwshkl-5 iuWgyE"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
+        />
+        <p
+          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          disabled={false}
         />
       </div>
     </div>
@@ -1951,7 +1979,7 @@ exports[`Storyshots InlineInputField With Icon 1`] = `
         </svg>
       </span>
       <p
-        className="InlineInputField__LabelText-jwshkl-1 gzviAo"
+        className="InlineInputField__LabelText-jwshkl-1 eufKgE"
         disabled={false}
       >
         Label text
@@ -1961,14 +1989,18 @@ exports[`Storyshots InlineInputField With Icon 1`] = `
       className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
     >
       <div
-        className="InlineInputField__InputWrapper-jwshkl-4 bInEel"
+        className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 gIJAcl"
+          className="InlineInputField__Input-jwshkl-5 iuWgyE"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
+        />
+        <p
+          className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+          disabled={false}
         />
       </div>
     </div>
@@ -1986,7 +2018,7 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
 <div
   style={
     Object {
-      "width": "250px",
+      "width": "400px",
     }
   }
 >
@@ -1998,34 +2030,170 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
     }
   >
     <div
-      className="InlineInputField__FullInputContainer-jwshkl-0 iHFQNH"
-      label=""
-      prefix="1.280€ "
+      className="InlineInputField__FullInputContainer-jwshkl-0 cWbDNN"
+      label="With prefix and suffix"
+      prefix="1.280€"
     >
-      
+      <label
+        className="InlineInputField__Label-jwshkl-7 kZozSM"
+      >
+        <p
+          className="InlineInputField__LabelText-jwshkl-1 eufKgE"
+          disabled={false}
+        >
+          With prefix and suffix
+        </p>
+      </label>
       <div
         className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
       >
         <div
-          className="InlineInputField__InputWrapper-jwshkl-4 bInEel"
-          prefix="1.280€ "
+          className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
+          prefix="1.280€"
         >
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 jDepsm prefix"
+            className="InlineInputField__InnerLabel-jwshkl-8 ApwTw prefix"
+            disabled={false}
           >
-            1.280€ 
+            1.280€
           </p>
           <input
-            className="InlineInputField__Input-jwshkl-5 gQLdgH"
+            className="InlineInputField__Input-jwshkl-5 iSdslR"
             disabled={false}
-            placeholder="Placeholder text"
-            prefix="1.280€ "
+            prefix="1.280€"
             type="text"
-            value="25%"
+            value="2"
+          />
+          <p
+            className="InlineInputField__InnerLabel-jwshkl-8 ghDJHO suffix"
+            disabled={false}
+            prefix="1.280€"
+          >
+            %
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      className="InlineInputField__FullInputContainer-jwshkl-0 cWbDNN"
+      label="Only prefix"
+      prefix="1.280€"
+    >
+      <label
+        className="InlineInputField__Label-jwshkl-7 kZozSM"
+      >
+        <p
+          className="InlineInputField__LabelText-jwshkl-1 eufKgE"
+          disabled={false}
+        >
+          Only prefix
+        </p>
+      </label>
+      <div
+        className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
+      >
+        <div
+          className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
+          prefix="1.280€"
+        >
+          <p
+            className="InlineInputField__InnerLabel-jwshkl-8 ApwTw prefix"
+            disabled={false}
+          >
+            1.280€
+          </p>
+          <input
+            className="InlineInputField__Input-jwshkl-5 iSdslR"
+            disabled={false}
+            prefix="1.280€"
+            type="text"
+            value="2"
+          />
+          <p
+            className="InlineInputField__InnerLabel-jwshkl-8 ghDJHO suffix"
+            disabled={false}
+            prefix="1.280€"
           />
         </div>
       </div>
-      
+    </div>
+    <div
+      className="InlineInputField__FullInputContainer-jwshkl-0 cWbDNN"
+      label="Only prefix disabled"
+      prefix="1.280€"
+    >
+      <label
+        className="InlineInputField__Label-jwshkl-7 kZozSM"
+      >
+        <p
+          className="InlineInputField__LabelText-jwshkl-1 dSHaNK"
+          disabled={true}
+        >
+          Only prefix disabled
+        </p>
+      </label>
+      <div
+        className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
+      >
+        <div
+          className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
+          prefix="1.280€"
+        >
+          <p
+            className="InlineInputField__InnerLabel-jwshkl-8 hSxllS prefix"
+            disabled={true}
+          >
+            1.280€
+          </p>
+          <input
+            className="InlineInputField__Input-jwshkl-5 iSdslR"
+            disabled={true}
+            prefix="1.280€"
+            type="text"
+            value="2"
+          />
+          <p
+            className="InlineInputField__InnerLabel-jwshkl-8 cJETTp suffix"
+            disabled={true}
+            prefix="1.280€"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="InlineInputField__FullInputContainer-jwshkl-0 cWbDNN"
+      label="Only suffix"
+    >
+      <label
+        className="InlineInputField__Label-jwshkl-7 kZozSM"
+      >
+        <p
+          className="InlineInputField__LabelText-jwshkl-1 eufKgE"
+          disabled={false}
+        >
+          Only suffix
+        </p>
+      </label>
+      <div
+        className="InlineInputField__InputContainer-jwshkl-6 fnlFeX"
+      >
+        <div
+          className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
+        >
+          <input
+            className="InlineInputField__Input-jwshkl-5 hzLOcN"
+            disabled={false}
+            type="text"
+            value="2"
+          />
+          <p
+            className="InlineInputField__InnerLabel-jwshkl-8 ApwTw suffix"
+            disabled={false}
+          >
+            %
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/InlineInputField/__snapshots__/InlineInputField.stories.storyshot
+++ b/src/components/InlineInputField/__snapshots__/InlineInputField.stories.storyshot
@@ -29,14 +29,14 @@ exports[`Storyshots InlineInputField Disabled 1`] = `
         className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 iuWgyE"
+          className="InlineInputField__Input-jwshkl-5 dftMSU"
           disabled={true}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 ibraJM suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 cYazfV suffix"
           disabled={true}
         />
       </div>
@@ -80,14 +80,14 @@ exports[`Storyshots InlineInputField Error 1`] = `
         className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 iuWgyE error"
+          className="InlineInputField__Input-jwshkl-5 dftMSU error"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 iaVPks suffix"
           disabled={false}
         />
       </div>
@@ -132,14 +132,14 @@ exports[`Storyshots InlineInputField Playground 1`] = `
         className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 iuWgyE"
+          className="InlineInputField__Input-jwshkl-5 dftMSU"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 iaVPks suffix"
           disabled={false}
         />
       </div>
@@ -183,14 +183,14 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
         className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 hzLOcN"
+          className="InlineInputField__Input-jwshkl-5 eLotnl"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 iaVPks suffix"
           disabled={false}
         />
       </div>
@@ -769,14 +769,14 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
         className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 iuWgyE"
+          className="InlineInputField__Input-jwshkl-5 dftMSU"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 iaVPks suffix"
           disabled={false}
         />
       </div>
@@ -1355,14 +1355,14 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
         className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 hzLOcN"
+          className="InlineInputField__Input-jwshkl-5 eLotnl"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 iaVPks suffix"
           disabled={false}
         />
       </div>
@@ -1395,14 +1395,14 @@ exports[`Storyshots InlineInputField Several Alignment 1`] = `
         className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 iuWgyE"
+          className="InlineInputField__Input-jwshkl-5 dftMSU"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 iaVPks suffix"
           disabled={false}
         />
       </div>
@@ -1992,14 +1992,14 @@ exports[`Storyshots InlineInputField With Icon 1`] = `
         className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
       >
         <input
-          className="InlineInputField__Input-jwshkl-5 iuWgyE"
+          className="InlineInputField__Input-jwshkl-5 dftMSU"
           disabled={false}
           placeholder="Placeholder text"
           type="text"
           value="Value text"
         />
         <p
-          className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
+          className="InlineInputField__InnerLabel-jwshkl-8 iaVPks suffix"
           disabled={false}
         />
       </div>
@@ -2031,7 +2031,7 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
   >
     <div
       className="InlineInputField__FullInputContainer-jwshkl-0 cWbDNN"
-      label="With prefix and suffix"
+      label="With prefix, suffix and narrow"
       prefix="1.280€"
     >
       <label
@@ -2041,7 +2041,7 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
           className="InlineInputField__LabelText-jwshkl-1 eufKgE"
           disabled={false}
         >
-          With prefix and suffix
+          With prefix, suffix and narrow
         </p>
       </label>
       <div
@@ -2052,24 +2052,23 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
           prefix="1.280€"
         >
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx prefix"
+            className="InlineInputField__InnerLabel-jwshkl-8 ebfxum prefix"
             disabled={false}
           >
             1.280€
           </p>
           <input
-            className="InlineInputField__Input-jwshkl-5 iSdslR"
+            className="InlineInputField__Input-jwshkl-5 lcdqDy"
             disabled={false}
             prefix="1.280€"
             type="text"
             value="2"
           />
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 dtkNsR suffix"
+            className="InlineInputField__InnerLabel-jwshkl-8 ebfxum suffix"
             disabled={false}
-            prefix="1.280€"
           >
-            %
+            % yoy
           </p>
         </div>
       </div>
@@ -2106,22 +2105,21 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
           prefix="1.280€"
         >
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx prefix"
+            className="InlineInputField__InnerLabel-jwshkl-8 iaVPks prefix"
             disabled={false}
           >
             1.280€
           </p>
           <input
-            className="InlineInputField__Input-jwshkl-5 iSdslR"
+            className="InlineInputField__Input-jwshkl-5 cajtkM"
             disabled={false}
             prefix="1.280€"
             type="text"
             value="2"
           />
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 dtkNsR suffix"
+            className="InlineInputField__InnerLabel-jwshkl-8 iaVPks suffix"
             disabled={false}
-            prefix="1.280€"
           />
         </div>
       </div>
@@ -2158,22 +2156,21 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
           prefix="1.280€"
         >
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 ibraJM prefix"
+            className="InlineInputField__InnerLabel-jwshkl-8 cYazfV prefix"
             disabled={true}
           >
             1.280€
           </p>
           <input
-            className="InlineInputField__Input-jwshkl-5 iSdslR"
+            className="InlineInputField__Input-jwshkl-5 cajtkM"
             disabled={true}
             prefix="1.280€"
             type="text"
             value="2"
           />
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 cnGIno suffix"
+            className="InlineInputField__InnerLabel-jwshkl-8 cYazfV suffix"
             disabled={true}
-            prefix="1.280€"
           />
         </div>
       </div>
@@ -2208,13 +2205,13 @@ exports[`Storyshots InlineInputField With Inner Labels 1`] = `
           className="InlineInputField__InputWrapper-jwshkl-4 jIUBmO"
         >
           <input
-            className="InlineInputField__Input-jwshkl-5 hzLOcN"
+            className="InlineInputField__Input-jwshkl-5 eLotnl"
             disabled={false}
             type="text"
             value="2"
           />
           <p
-            className="InlineInputField__InnerLabel-jwshkl-8 Ifmqx suffix"
+            className="InlineInputField__InnerLabel-jwshkl-8 iaVPks suffix"
             disabled={false}
           >
             %

--- a/src/components/InlineInputField/index.d.ts
+++ b/src/components/InlineInputField/index.d.ts
@@ -4,13 +4,15 @@ export interface InputFieldProps {
   error?: boolean;
   help?: string;
   label?: string | React.ReactNode;
+  labelIcon?: React.ReactNode;
   name?: string;
   onChange?: (ev: SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>;
   placeholder?: string;
+  prefix?: string;
+  suffix?: string;
   tabIndex?: string;
+  textAlign?: 'left' | 'right';
   type: string;
-  labelIcon: React.ReactNode;
-  textAlign: 'left' | 'right';
   value?: string;
 }
 

--- a/src/components/InlineInputField/index.d.ts
+++ b/src/components/InlineInputField/index.d.ts
@@ -3,6 +3,7 @@ export interface InputFieldProps {
   disabled?: boolean;
   error?: boolean;
   help?: string;
+  inputBackground?: string;
   label?: string | React.ReactNode;
   labelIcon?: React.ReactNode;
   name?: string;
@@ -13,7 +14,7 @@ export interface InputFieldProps {
   tabIndex?: string;
   textAlign?: 'left' | 'right';
   type: string;
-  value?: string;
+  value?: string | number;
 }
 
 declare const InputField: React.FunctionComponent<

--- a/src/components/InlineInputField/index.d.ts
+++ b/src/components/InlineInputField/index.d.ts
@@ -15,6 +15,8 @@ export interface InputFieldProps {
   textAlign?: 'left' | 'right';
   type: string;
   value?: string | number;
+  narrow?: boolean;
+  boldContent?: boolean;
 }
 
 declare const InputField: React.FunctionComponent<

--- a/src/components/InlineInputField/index.js
+++ b/src/components/InlineInputField/index.js
@@ -70,17 +70,17 @@ const InputWrapper = styled.div`
 const Input = styled.input`
   width: 100%;
   font-family: ${({ theme }) => theme.global.fontFamily};
-  ${({ theme, prefix }) => (prefix ? theme.texts.p1b : theme.texts.p1)};
+  ${({ theme, boldContent }) => (boldContent ? theme.texts.p1b : theme.texts.p1)};
   padding-right: ${({ theme, textAlign, prefix, suffixWidth }) =>
     (textAlign === 'right') & (prefix && suffixWidth)
       ? theme.spacings.small3
-      : `calc(${suffixWidth} + 2px)`};
+      : `calc(${suffixWidth} + 1px)`};
   text-align: ${({ textAlign, prefix, suffix }) => (prefix || suffix ? 'right' : textAlign)};
-  font-weight: ${({ theme, prefix }) => (prefix ? theme.global.fontWeightMedium : '')};
-  line-height: ${({ theme, prefix }) =>
-    prefix
+  line-height: ${({ theme, narrow }) =>
+    narrow
       ? theme.components.inlineInputFieldPrefixLineHeight
       : theme.components.inlineInputFieldLineHeight};
+
   text-indent: ${({ theme, prefix }) => (prefix ? 0 : theme.components.inlineInputFieldTextIndent)};
   padding-left: ${({ prefix, prefixWidth }) => (prefix ? prefixWidth : 0)};
   background-color: transparent;
@@ -138,24 +138,26 @@ Label.defaultProps = {
 
 const InnerLabel = styled.p`
   position: absolute;
-  ${({ theme }) => theme.texts.p1b};
-  max-width: 100px;
   overflow: hidden;
   white-space: nowrap;
 
   &.prefix {
-    padding: 6px 10px 0 ${({ theme }) => theme.spacings.small3};
+    max-width: 100px;
+    top: ${({ narrow }) => (narrow ? '6px' : '10px')};
+    padding-left: ${({ theme }) => theme.spacings.small3};
+    ${({ theme }) => theme.texts.p1b};
     color: ${({ theme, disabled }) =>
       disabled ? theme.components.inlineInputFieldDisabledLabelColor : theme.color.charcoal600};
   }
 
   &.suffix {
-    top: ${({ prefix }) => (prefix ? '6px' : '10px')};
+    max-width: fit-content;
+    top: ${({ narrow }) => (narrow ? '6px' : '10px')};
     right: 0;
     padding-right: ${({ theme }) => theme.spacings.small3};
+    ${({ theme, boldContent }) => (boldContent ? theme.texts.p1b : theme.texts.p1)};
     color: ${({ theme, disabled }) =>
       disabled ? theme.components.inlineInputFieldDisabledLabelColor : theme.color.charcoal800};
-    ${({ theme, prefix }) => (prefix ? theme.texts.p1b : theme.texts.p1)}
   }
 `;
 
@@ -173,6 +175,8 @@ const InlineInputField = React.forwardRef((props, ref) => {
     placeholder,
     prefix,
     suffix,
+    boldContent,
+    narrow,
     tabIndex,
     textAlign,
     type,
@@ -217,6 +221,8 @@ const InlineInputField = React.forwardRef((props, ref) => {
                 ref={node => {
                   getPrefixWidth(node);
                 }}
+                boldContent={boldContent}
+                narrow={narrow}
                 className={'prefix'}
               >
                 {prefix}
@@ -226,12 +232,14 @@ const InlineInputField = React.forwardRef((props, ref) => {
               textAlign={textAlign}
               className={error ? `error` : null}
               type={type}
+              narrow={narrow}
               prefixWidth={prefixWidth}
               suffixWidth={suffixWidth}
               disabled={disabled}
               prefix={prefix}
               suffix={suffix}
               value={value}
+              boldContent={boldContent}
               name={name}
               onChange={onChange}
               placeholder={placeholder}
@@ -240,18 +248,24 @@ const InlineInputField = React.forwardRef((props, ref) => {
             ></Input>
             <InnerLabel
               disabled={disabled}
-              prefix={prefix}
               ref={node => {
                 getSuffixWidth(node);
               }}
               className="suffix"
+              narrow={narrow}
+              boldContent={boldContent}
             >
               {suffix}
             </InnerLabel>
           </InputWrapper>
         </InputContainer>
         {help && (
-          <HelpText label={label} textAlign={textAlign} className={error ? 'error' : null}>
+          <HelpText
+            boldContent={boldContent}
+            label={label}
+            textAlign={textAlign}
+            className={error ? 'error' : null}
+          >
             {help}
           </HelpText>
         )}
@@ -276,14 +290,18 @@ InlineInputField.propTypes = {
   labelIcon: PropTypes.node,
   prefix: PropTypes.string,
   suffix: PropTypes.string,
-  inputBackground: PropTypes.string
+  inputBackground: PropTypes.string,
+  narrow: PropTypes.bool,
+  boldContent: PropTypes.bool
 };
 
 InlineInputField.defaultProps = {
   value: '',
   textAlign: 'left',
   disabled: false,
-  type: 'text'
+  type: 'text',
+  boldContent: false,
+  narrow: false
 };
 
 InlineInputField.displayName = 'InlineInputField';

--- a/src/components/InlineInputField/index.js
+++ b/src/components/InlineInputField/index.js
@@ -138,7 +138,7 @@ Label.defaultProps = {
 
 const InnerLabel = styled.p`
   position: absolute;
-  ${({ theme }) => theme.texts.p1};
+  ${({ theme }) => theme.texts.p1b};
   max-width: 100px;
   overflow: hidden;
   white-space: nowrap;

--- a/src/components/InputField/__snapshots__/InputField.stories.storyshot
+++ b/src/components/InputField/__snapshots__/InputField.stories.storyshot
@@ -13,7 +13,7 @@ exports[`Storyshots InputField Disabled 1`] = `
       className="InputField__Label-sc-1kf04eo-3 ckeGRO"
     >
       <input
-        className="InputField__Input-sc-1kf04eo-2 ePOZCe"
+        className="InputField__Input-sc-1kf04eo-2 fpIUFd"
         disabled={true}
         placeholder="Placeholder text"
         type="text"
@@ -48,7 +48,7 @@ exports[`Storyshots InputField Error 1`] = `
       className="InputField__Label-sc-1kf04eo-3 ckeGRO"
     >
       <input
-        className="InputField__Input-sc-1kf04eo-2 ePOZCe error"
+        className="InputField__Input-sc-1kf04eo-2 fpIUFd error"
         disabled={false}
         placeholder="Placeholder text"
         type="text"
@@ -83,7 +83,7 @@ exports[`Storyshots InputField Normal 1`] = `
       className="InputField__Label-sc-1kf04eo-3 ckeGRO"
     >
       <input
-        className="InputField__Input-sc-1kf04eo-2 ePOZCe"
+        className="InputField__Input-sc-1kf04eo-2 fpIUFd"
         disabled={false}
         placeholder="Placeholder text"
         type="text"

--- a/src/components/InputField/index.js
+++ b/src/components/InputField/index.js
@@ -31,6 +31,7 @@ HelpText.defaultProps = {
 };
 
 export const Input = styled.input`
+  font-family: ${({ theme }) => theme.global.fontFamily};
   appearance: none;
   outline: 0;
   font-size: ${({ theme }) => theme.components.inputFieldFontSize};

--- a/src/themes/defaultTheme.js
+++ b/src/themes/defaultTheme.js
@@ -365,6 +365,10 @@ const components = {
   inputFieldPlaceholderColor: color.charcoal400,
   inputFieldTextIndent: spacings.small4,
 
+  /*InlineInputField Theme props*/
+
+  inlineInputFieldLabelColor: color.charcoal800,
+
   /*TextareaField Theme props*/
 
   textareaFieldBackgroundColor: color.white,


### PR DESCRIPTION
Nuevas funcionalidades: 

- Admite propiedad de backgroundColor:
![image](https://user-images.githubusercontent.com/47493473/114065165-a543c680-989a-11eb-80bd-4508d2e7fdfb.png)

- Incluye propiedad Suffix:

- Incluye propiedad 'narrow":  permite activar la versión estrecha del campo, prefijo y sufijo se ajustan en consecuencia.

- Incluye propiedad 'boldContent': permite indicar si sufijo y valor deben estar en negrita o no.

![image](https://user-images.githubusercontent.com/47493473/114154474-bb946580-9920-11eb-8e0b-dc063f44afd6.png)


Fixes:
- Tamaño del label acorde al diseño de Figma (antes a 12px, ahora a 14px)
- Tamaño del interior del campo acorde a Figma (antes a 12 ahora a 14px)
- El color de la label, el prefix y el suffix cambian cuando el input es disabled.
- El input ahora espera String o Number
- Color de la label, ajustado a charcoal800
- AlignText, solamente permite alinear el texto a la izquierda mientras no haya no prefijos ni sufijos aplicados.
- Sustitución de estilos específicos por estilos globales de p1 y p1b
- Cambio de la fuente del contenido del input de Arial a Roboto, también en el InputField.
