### PR TITLE
feat: add customizable background and font colors to card content

### DIFF
--- a/src/components/Card/Card.stories.js
+++ b/src/components/Card/Card.stories.js
@@ -28,6 +28,14 @@ export default {
       table: {
         category: 'format'
       }
+    },
+    contentBackgroundColor: {
+      control: 'text',
+      description: 'Allows to customize the background color of the card content'
+    },
+    contentFontColor: {
+      control: 'text',
+      description: 'Allos to customize the font color of the card content'
     }
   },
   args: {
@@ -39,14 +47,19 @@ const containerStyle = {
   padding: '2rem'
 };
 
-export const Playground = args => {
+export const Playground = ({ contentBackgroundColor, contentFontColor, ...args }) => {
   return (
     <div style={containerStyle}>
       <Card {...args}>
         <CardHeader leftContent="Left" rightContent="Right" title="Title" subheader="Subtitle">
           Extra content
         </CardHeader>
-        <CardContent>Lorem Ipsum</CardContent>
+        <CardContent
+          contentBackgroundColor={contentBackgroundColor}
+          contentFontColor={contentFontColor}
+        >
+          Lorem Ipsum
+        </CardContent>
       </Card>
     </div>
   );
@@ -56,6 +69,21 @@ export const Loading = () => {
   return (
     <div style={containerStyle}>
       <Card loading></Card>
+    </div>
+  );
+};
+
+export const colouredContent = () => {
+  return (
+    <div style={containerStyle}>
+      <Card>
+        <CardHeader leftContent="Left" rightContent="Right" title="Title" subheader="Subtitle">
+          Extra content
+        </CardHeader>
+        <CardContent contentBackgroundColor="darkblue" contentFontColor="white">
+          Lorem Ipsum
+        </CardContent>
+      </Card>
     </div>
   );
 };

--- a/src/components/Card/Card.stories.js
+++ b/src/components/Card/Card.stories.js
@@ -35,7 +35,7 @@ export default {
     },
     contentFontColor: {
       control: 'text',
-      description: 'Allos to customize the font color of the card content'
+      description: 'Allows to customize the font color of the card content'
     }
   },
   args: {
@@ -47,10 +47,31 @@ const containerStyle = {
   padding: '2rem'
 };
 
-export const Playground = ({ contentBackgroundColor, contentFontColor, ...args }) => {
+export const Playground = ({ ...args }) => {
   return (
     <div style={containerStyle}>
       <Card {...args}>
+        <CardHeader leftContent="Left" rightContent="Right" title="Title" subheader="Subtitle">
+          Extra content
+        </CardHeader>
+        <CardContent>Lorem Ipsum</CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export const Loading = () => {
+  return (
+    <div style={containerStyle}>
+      <Card loading></Card>
+    </div>
+  );
+};
+
+export const colouredContent = ({ contentBackgroundColor, contentFontColor, ...args }) => {
+  return (
+    <div style={containerStyle}>
+      <Card>
         <CardHeader leftContent="Left" rightContent="Right" title="Title" subheader="Subtitle">
           Extra content
         </CardHeader>
@@ -65,25 +86,7 @@ export const Playground = ({ contentBackgroundColor, contentFontColor, ...args }
   );
 };
 
-export const Loading = () => {
-  return (
-    <div style={containerStyle}>
-      <Card loading></Card>
-    </div>
-  );
-};
-
-export const colouredContent = () => {
-  return (
-    <div style={containerStyle}>
-      <Card>
-        <CardHeader leftContent="Left" rightContent="Right" title="Title" subheader="Subtitle">
-          Extra content
-        </CardHeader>
-        <CardContent contentBackgroundColor="darkblue" contentFontColor="white">
-          Lorem Ipsum
-        </CardContent>
-      </Card>
-    </div>
-  );
+colouredContent.args = {
+  contentBackgroundColor: 'darkblue',
+  contentFontColor: 'white'
 };

--- a/src/components/Card/CardContent/index.d.ts
+++ b/src/components/Card/CardContent/index.d.ts
@@ -1,6 +1,8 @@
 export interface CardContentProps {
   children?: React.ReactNode;
   className?: string;
+  contentBackgroundColor?: string;
+  contentFontColor?: string;
 }
 
 declare const CardContent: React.FunctionComponent<CardContentProps>;

--- a/src/components/Card/CardContent/index.js
+++ b/src/components/Card/CardContent/index.js
@@ -5,7 +5,8 @@ import defaultTheme from '../../../themes/defaultTheme';
 
 const StyledCardContent = styled.div`
   padding: ${({ theme }) => theme.spacings.small3} ${({ theme }) => theme.spacings.small4};
-  background-color: ${({ theme }) => theme.color.charcoal300};
+  background-color: ${({ contentBackgroundColor }) => contentBackgroundColor};
+  color: ${({ contentFontColor }) => contentFontColor};
 `;
 
 StyledCardContent.defaultProps = {
@@ -13,18 +14,29 @@ StyledCardContent.defaultProps = {
 };
 
 const CardContent = React.forwardRef((props, ref) => {
-  const { children, className, ...other } = props;
+  const { children, className, backgroundColor, fontColor, ...other } = props;
 
   return (
-    <StyledCardContent className={className} {...other}>
+    <StyledCardContent
+      className={className}
+      contentBackgroundColor={backgroundColor}
+      contentFontColor={fontColor}
+      {...other}
+    >
       {children}
     </StyledCardContent>
   );
 });
 
+CardContent.defaultProps = {
+  backgroundColor: defaultTheme.color.charcoal300
+};
+
 CardContent.propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  contentBackgroundColor: PropTypes.string,
+  contentFontColor: PropTypes.string
 };
 CardContent.displayName = 'CardContent';
 

--- a/src/components/Card/CardContent/index.js
+++ b/src/components/Card/CardContent/index.js
@@ -5,7 +5,8 @@ import defaultTheme from '../../../themes/defaultTheme';
 
 const StyledCardContent = styled.div`
   padding: ${({ theme }) => theme.spacings.small3} ${({ theme }) => theme.spacings.small4};
-  background-color: ${({ contentBackgroundColor }) => contentBackgroundColor};
+  background-color: ${({ contentBackgroundColor, theme }) =>
+    contentBackgroundColor ? contentBackgroundColor : theme.color.charcoal300};
   color: ${({ contentFontColor }) => contentFontColor};
 `;
 
@@ -14,13 +15,13 @@ StyledCardContent.defaultProps = {
 };
 
 const CardContent = React.forwardRef((props, ref) => {
-  const { children, className, backgroundColor, fontColor, ...other } = props;
+  const { children, className, contentBackgroundColor, contentFontColor, ...other } = props;
 
   return (
     <StyledCardContent
       className={className}
-      contentBackgroundColor={backgroundColor}
-      contentFontColor={fontColor}
+      contentBackgroundColor={contentBackgroundColor}
+      contentFontColor={contentFontColor}
       {...other}
     >
       {children}
@@ -29,7 +30,7 @@ const CardContent = React.forwardRef((props, ref) => {
 });
 
 CardContent.defaultProps = {
-  backgroundColor: defaultTheme.color.charcoal300
+  contentBackgroundColor: defaultTheme.color.charcoal300
 };
 
 CardContent.propTypes = {

--- a/src/components/Card/__snapshots__/Card.stories.storyshot
+++ b/src/components/Card/__snapshots__/Card.stories.storyshot
@@ -1,5 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Card Coloured Content 1`] = `
+<div
+  style={
+    Object {
+      "padding": "2rem",
+    }
+  }
+>
+  <article
+    className="Card__StyledCard-sc-1saz4sv-0 dYtRjf"
+  >
+    <header
+      className="CardHeader__StyledCardHeader-dpp5o1-0 hrzGbb"
+    >
+      <div
+        className="CardHeader__StyledContainer-dpp5o1-1 hDziRf"
+      >
+        <div>
+          Left
+        </div>
+        <div>
+          <div>
+            Title
+          </div>
+          <div>
+            Subtitle
+          </div>
+        </div>
+        <div
+          className="CardHeader__StyledRightContent-dpp5o1-3 iyVebu"
+        >
+          Right
+        </div>
+      </div>
+      <div
+        className="CardHeader__StyledChildrenContainer-dpp5o1-2 esYIOD"
+      >
+        Extra content
+      </div>
+    </header>
+    <div
+      className="CardContent__StyledCardContent-dh88vi-0 kVhzKc"
+    >
+      Lorem Ipsum
+    </div>
+  </article>
+</div>
+`;
+
 exports[`Storyshots Card Loading 1`] = `
 <div
   style={
@@ -203,7 +252,7 @@ exports[`Storyshots Card Playground 1`] = `
       </div>
     </header>
     <div
-      className="CardContent__StyledCardContent-dh88vi-0 cQuoHH"
+      className="CardContent__StyledCardContent-dh88vi-0 jMBJQt"
     >
       Lorem Ipsum
     </div>

--- a/src/components/Card/__snapshots__/Card.stories.storyshot
+++ b/src/components/Card/__snapshots__/Card.stories.storyshot
@@ -252,7 +252,7 @@ exports[`Storyshots Card Playground 1`] = `
       </div>
     </header>
     <div
-      className="CardContent__StyledCardContent-dh88vi-0 jMBJQt"
+      className="CardContent__StyledCardContent-dh88vi-0 jHVHWB"
     >
       Lorem Ipsum
     </div>


### PR DESCRIPTION
Permite customizar el color del componente 'cardContent` tanto de fondo como de fuente.  Son propiedades opcionales. En caso de no especificarse el valor por defecto es el gris charcoal 300 y el color por defecto del tema para la fuente. 

![image](https://user-images.githubusercontent.com/47493473/115258076-f5d7e100-a130-11eb-8a53-5d1ea357b35e.png)
